### PR TITLE
Support exotic tld's

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -645,7 +645,7 @@ def main():
         enable_bruteforce = True
 
     #Validate domain
-    domain_check = re.compile("^(http|https)?[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,5}$")
+    domain_check = re.compile("^(http|https)?[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,}$")
     if not domain_check.match(domain):
         print R+"Error: Please enter a valid domain"+W
         sys.exit()


### PR DESCRIPTION
Custom TLD's can be longer than 5 symbols, I've updated the regex so we can look for more exotic domains like .travel as well.