### PR TITLE
Add requirements.txt for dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+argparse
+dnspython
+requests


### PR DESCRIPTION
Allows users to install dependencies using pip -r requirements.txt