### PR TITLE
Fixed minor bug with DNS lookup

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -607,11 +607,10 @@ class DNSdumpster(enumratorBaseThreaded):
         self.lock.acquire()
         try:
             ip = Resolver.query(host, 'A')[0].to_text()
-            if ip:
-                if self.verbose:
-                    self.print_("%s%s: %s%s" % (R, self.engine_name, W, host))
-                is_valid = True
-                self.live_subdomains.append(host)
+            if self.verbose:
+                self.print_("%s%s: %s%s" % (R, self.engine_name, W, host))
+            is_valid = True
+            self.live_subdomains.append(host)
         except:
             pass
         self.lock.release()


### PR DESCRIPTION
The removed if statement is always false. If the DNS lookup was successful then the `ip` variable would contain the IP-address. If it was unsuccessful then `resolver.query` will throw an exception.