### PR TITLE
Fix PassiveDNS module

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -839,7 +839,7 @@ class PassiveDNS(enumratorBaseThreaded):
 
     def req(self, url):
         headers = {
-            'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/40.0',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36',
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'Accept-Language': 'en-GB,en;q=0.5',
             'Accept-Encoding': 'gzip, deflate',


### PR DESCRIPTION
This fixes the PassiveDNS module by changing the user agent. 

Currently this module gives incorrect records like given below.
hackertrace1.internal.nsa.gov.example.com
hackertrace2.internal.nsa.gov.example.com
hackertrace3.internal.nsa.gov.example.com
hackertrace4.internal.nsa.gov.example.com

Thanks