### PR TITLE
punycode/IDN #72

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -919,13 +919,13 @@ def main(domain, threads, savefile, ports, silent, verbose, enable_bruteforce, e
         enable_bruteforce = True
 
     # Validate domain
-    domain_check = re.compile("^(http|https)?[a-zA-Z0-9]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,}$")
+    domain_check = re.compile("^(?:[a-zA-Z][a-zA-Z0-9+.-]*:\/\/)?[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\/?$")
     if not domain_check.match(domain):
         if not silent:
             print(R + "Error: Please enter a valid domain" + W)
         return []
 
-    if not domain.startswith('http://') or not domain.startswith('https://'):
+    if not re.compile("^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/").match(domain):
         domain = 'http://' + domain
 
     parsed_domain = urlparse.urlparse(domain)


### PR DESCRIPTION
This regex not validating punycode domains like `xn--h1alffa9f.xn--p1ai`.

Reason of using punycode is that unicode input like россия.рф not working on python2, on python3 it is finding much less domains than punycode input.

Enumerator | Unicode | Punycode
--- | --- | ---
Baidu | :x: | :x:
Yahoo | :x: | :white_check_mark:
Google | :white_check_mark: | :white_check_mark:
Bing | :x: | :white_check_mark:
Ask | :white_check_mark: | :white_check_mark:
Netcraft | :x: | :x:
DNSdumpster | :x: | :white_check_mark:
Virustotal | :x: | :white_check_mark:
ThreatCrowd | :x: | :white_check_mark:
SSL Certificates | :x: | :white_check_mark:
PassiveDNS | :x: | :x: