### PR TITLE
Fix for PassiveDNS module

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -839,7 +839,7 @@ class PassiveDNS(enumratorBaseThreaded):
 
     def req(self, url):
         headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36',
+            'User-Agent': 'Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16',
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             'Accept-Language': 'en-GB,en;q=0.5',
             'Accept-Encoding': 'gzip, deflate',


### PR DESCRIPTION
It seem's like ptrarchive.com is now blocking Google Chrome user agent as well. Current Sublist3r is giving same output as https://github.com/aboul3la/Sublist3r/pull/71 . 

To fix that i have changed user agent string from Chrome web browser to Opera.

Thanks