### PR TITLE
corrected redhat/centos based installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,7 @@ sudo pip install dnspython
 sudo apt-get install python-argparse
 ```
 
-- Install for Centos/Redhat:
-```
-sudo yum install python-argparse
-``` 
-
-- Install using pip:
+- Install using Centos/Redhat/pip:
 ```
 sudo pip install argparse
 ```


### PR DESCRIPTION
As the current instructions for:
sudo yum install python-argparse currently don't work under centos based distros