### PR TITLE
Fix deadlock in subbrute, thanks to @tomer70

### DIFF
--- a/subbrute/subbrute.py
+++ b/subbrute/subbrute.py
@@ -163,7 +163,7 @@ class verify_nameservers(multiprocessing.Process):
                             #We found atleast one wildcard, look for more.
                             looking_for_wildcards = True
             except Exception as e:
-                if type(e) == dns.resolver.NXDOMAIN or type(e) == dns.name.EmptyLabel:
+                if type(e) == dns.resolver.NXDOMAIN or type(e) == dns.name.EmptyLabel or type(e) == dns.resolver.NoAnswer:
                     #not found
                     return True
                 else:
@@ -194,7 +194,7 @@ class lookup(multiprocessing.Process):
         ret = []
         try:
             ret = [self.resolver_q.get_nowait()]
-            if ret == False:
+            if ret == [False]:
                 #Queue is empty,  inform the rest.
                 self.resolver_q.put(False)
                 ret = []
@@ -205,7 +205,7 @@ class lookup(multiprocessing.Process):
     def get_ns_blocking(self):
         ret = []
         ret = [self.resolver_q.get()]
-        if ret == False:
+        if ret == [False]:
             trace("get_ns_blocking - Resolver list is empty.")
             #Queue is empty,  inform the rest.
             self.resolver_q.put(False)


### PR DESCRIPTION
This is in relation to both issue  #26 and #123.

In get_ns and get_ns_blocking methods, the comparison in the 'if ret == False' statement would always fail (return False), as the variable ret is a list, and would either contain a resolver, or it would contain a single bool element with the value False (ex: [<resolver>] or [False]). Therefore, when it was [False], we would never enter into the if statement block, and never add False back to the resolver_q, eventually causing a deadlock in get_ns_blocking.