### PR TITLE
UTF-8 Encoded Issue Resolved

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -104,7 +104,7 @@ def parse_args():
 def write_file(filename, subdomains):
     # saving subdomains results to output file
     print("%s[-] Saving results to file: %s%s%s%s" % (Y, W, R, filename, W))
-    with open(str(filename), 'wt') as f:
+    with open(str(filename), 'wt',encoding='utf-8') as f:
         for subdomain in subdomains:
             f.write(subdomain + os.linesep)
 
@@ -545,7 +545,8 @@ class NetcraftEnum(enumratorBaseThreaded):
         cookies = dict()
         cookies_list = cookie[0:cookie.find(';')].split("=")
         cookies[cookies_list[0]] = cookies_list[1]
-        cookies['netcraft_js_verification_response'] = hashlib.sha1(urllib.unquote(cookies_list[1])).hexdigest()
+        # hashlib.sha1 requires utf-8 encoded str
+        cookies['netcraft_js_verification_response'] = hashlib.sha1(urllib.unquote(cookies_list[1]).encode('utf-8')).hexdigest()
         return cookies
 
     def get_cookies(self, headers):


### PR DESCRIPTION
Hey after the recent commit of encoding issue it was still giving the error because hashlib.sha1 was not getting `utf-8` encoded code but now it is resolved by me. I have defined the encoding utf-8 where I feel its important. "Fixed #145 #143  "
Here is the proof.
![screenshot_2018-10-02_21-47-17](https://user-images.githubusercontent.com/21127788/46362006-c0f80180-c68c-11e8-9a2a-230b1dafe786.png)
