### PR TITLE
relative path for subbrute include, issue #151

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -18,7 +18,7 @@ import json
 from collections import Counter
 
 # external modules
-from subbrute import subbrute
+from ..Sublist3r.subbrute import subbrute
 import dns.resolver
 import requests
 


### PR DESCRIPTION
I added the relative import path for subbrute to get Sublist3r to work as a client library under a Django project, but it looks like it might also address issue #151 .