### PR TITLE
Change port scanning to use ThreadPool

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -16,6 +16,7 @@ import threading
 import socket
 import json
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 
 # external modules
 from subbrute import subbrute
@@ -837,11 +838,10 @@ class portscan():
         self.subdomains = subdomains
         self.ports = ports
         self.threads = 20
-        self.lock = threading.BoundedSemaphore(value=self.threads)
+        self.pool = ThreadPoolExecutor(max_workers=self.threads)
 
     def port_scan(self, host, ports):
         openports = []
-        self.lock.acquire()
         for port in ports:
             try:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -852,14 +852,12 @@ class portscan():
                 s.close()
             except Exception:
                 pass
-        self.lock.release()
         if len(openports) > 0:
             print("%s%s%s - %sFound open ports:%s %s%s%s" % (G, host, W, R, W, Y, ', '.join(openports), W))
 
     def run(self):
         for subdomain in self.subdomains:
-            t = threading.Thread(target=self.port_scan, args=(subdomain, self.ports))
-            t.start()
+            self.pool.submit(self.port_scan, subdomain, self.ports)
 
 
 def main(domain, threads, savefile, ports, silent, verbose, enable_bruteforce, engines):


### PR DESCRIPTION
Sublist3r currently queues domains to be port scanned by creating a separate thread for each domain. This can be troublesome when hundreds - thousands of domains must be scanned. This pull request replaces the existing semaphore with a ThreadPool, which properly handles queuing port scans to limit the number of threads.