### PR TITLE
fixed the regex pattern for DNSDumpster's token

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -636,7 +636,7 @@ class DNSdumpster(enumratorBaseThreaded):
         return self.get_response(resp)
 
     def get_csrftoken(self, resp):
-        csrf_regex = re.compile("<input type='hidden' name='csrfmiddlewaretoken' value='(.*?)' />", re.S)
+        csrf_regex = re.compile('<input type="hidden" name="csrfmiddlewaretoken" value="(.*?)">', re.S)
         token = csrf_regex.findall(resp)[0]
         return token.strip()
 


### PR DESCRIPTION
this is a hotfix to the error 'list index out of range' that results from re.compile.findall returning an empty list due to a none match.
should later create a failsafe for all bad regex matches by testing whether the match is an empty list before proceeding to enum it.. or use a better way to match the desired string.. Maybe on a later commit, weh