### PR TITLE
Fix #210 / Remove unnecessary "<A style" from regex

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -788,7 +788,7 @@ class CrtSearch(enumratorBaseThreaded):
         return self.subdomains
 
     def extract_domains(self, resp):
-        link_regx = re.compile('<TD>(.*?)</TD>')
+        link_regx = re.compile('<TD>(?!<A)(.*?)</TD>')
         try:
             links = link_regx.findall(resp)
             for link in links:
@@ -798,6 +798,12 @@ class CrtSearch(enumratorBaseThreaded):
 
                 if '@' in subdomain:
                     subdomain = subdomain[subdomain.find('@')+1:]
+
+                if '<BR>' in subdomain:
+                    for brlink in subdomain.split('<BR>'):
+                        if brlink not in self.subdomains and brlink != self.domain:
+                            self.subdomains.append(brlink)
+                    continue
 
                 if subdomain not in self.subdomains and subdomain != self.domain:
                     if self.verbose:


### PR DESCRIPTION
The extra "<BR>" come from https://crt.sh/ when the SSL certificates has more than one DNS name on the certificate.
Also, the current regex is matching "<A style....." which are checked on the loop (unnecessary)