### PR TITLE
Using __subclasses__ method.

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -923,11 +923,7 @@ def main(domain, threads, savefile, ports, silent, verbose, enable_bruteforce, e
     chosenEnums = []
 
     if engines is None:
-        chosenEnums = [
-            BaiduEnum, YahooEnum, GoogleEnum, BingEnum, AskEnum,
-            NetcraftEnum, DNSdumpster, Virustotal, ThreatCrowd,
-            CrtSearch, PassiveDNS
-        ]
+        chosenEnums = enumratorBaseThreaded.__subclasses__()
     else:
         engines = engines.split(',')
         for engine in engines:


### PR DESCRIPTION
To get all enumratorBaseThreaded implementations, this way there no need to add manually.