### PR TITLE
In python3, no unicode type

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -300,7 +300,7 @@ class GoogleEnum(enumratorBaseThreaded):
         return links_list
 
     def check_response_errors(self, resp):
-        if (type(resp) is str or type(resp) is unicode) and 'Our systems have detected unusual traffic' in resp:
+        if (type(resp) is str or type(resp) is str) and 'Our systems have detected unusual traffic' in resp:
             self.print_(R + "[!] Error: Google probably now is blocking our requests" + W)
             self.print_(R + "[~] Finished now the Google Enumeration ..." + W)
             return False


### PR DESCRIPTION
In python3, string are encoded from str to bytes. In python2, string are encode from unicode to str.