### PR TITLE
Added a dot to make subbrute import relative

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -18,7 +18,7 @@ import json
 from collections import Counter
 
 # external modules
-from subbrute import subbrute
+from .subbrute import subbrute
 import dns.resolver
 import requests
 

--- a/sublist3r.py
+++ b/sublist3r.py
@@ -18,7 +18,10 @@ import json
 from collections import Counter
 
 # external modules
-from .subbrute import subbrute
+if __name__ == "__main__":
+    from subbrute import subbrute
+else:
+    from .subbrute import subbrute
 import dns.resolver
 import requests
 


### PR DESCRIPTION
The import ie. ```from Sublist3r import sublist3r``` fails when done from python interpreter or any other scripts. This little dot fixes the relative import issue. Now, we can do  ```from Sublist3r import sublist3r``` and use sublist3r within python.