### PR TITLE
Add toggle for silent, extend reach of silent

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Short Form    | Long Form     | Description
 -e            | --engines     | Specify a comma-separated list of search engines
 -o            | --output      | Save the results to text file
 -h            | --help        | show the help message and exit
+-q	      | --quiet       | No output to console
 
 ### Examples
 
@@ -138,7 +139,6 @@ Short Form    | Long Form     | Description
 * To enumerate subdomains and use specific engines such Google, Yahoo and Virustotal engines
 
 ``python sublist3r.py -e google,yahoo,virustotal -d example.com``
-
 
 ## Using Sublist3r as a module in your python scripts
 


### PR DESCRIPTION
Added a toggle switch, `-q, --quiet` to enable the silent feature available in the script.

Additionally, this pull request further extends the reach of the existing silent feature. Previously, when using Sublist3r as a module in another Python script, Sublist3r still displayed the banner as well as messages such as `Saving results to file`.

I believe having the option to toggle the silent option when running the script can be valuable to those that just want to generate the output to a file with the `-o` option, and can be useful when running multiple scripts in succession. Additionally, having silent mute other output such as the banner display will increase the usefulness of setting silent when calling Sublist3r from another script.

Closes #268 