### PR TITLE
Fix for VirusTotal error

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -676,7 +676,7 @@ class DNSdumpster(enumratorBaseThreaded):
 class Virustotal(enumratorBaseThreaded):
     def __init__(self, domain, subdomains=None, q=None, silent=False, verbose=True):
         subdomains = subdomains or []
-        base_url = 'https://www.virustotal.com/api/v3/domains/{domain}'
+        base_url = 'https://www.virustotal.com/api/v3/domains/{domain}/subdomains'
         self.engine_name = "Virustotal"
         self.apikey = os.getenv('VT_APIKEY', None)
         self.q = q
@@ -715,14 +715,15 @@ class Virustotal(enumratorBaseThreaded):
     def extract_domains(self, resp):
         #resp is already parsed as json
         try:
-            for i in resp['data']['attributes']['last_dns_records']:
-                subdomain = i['value']
-                if not subdomain.endswith(self.domain):
-                    continue
-                if subdomain not in self.subdomains and subdomain != self.domain:
-                    if self.verbose:
-                        self.print_("%s%s: %s%s" % (R, self.engine_name, W, subdomain))
-                    self.subdomains.append(subdomain.strip())
+            for i in resp['data']:
+                if i['type'] == 'domain':
+                    subdomain = i['id']
+                    if not subdomain.endswith(self.domain):
+                        continue
+                    if subdomain not in self.subdomains and subdomain != self.domain:
+                        if self.verbose:
+                            self.print_("%s%s: %s%s" % (R, self.engine_name, W, subdomain))
+                        self.subdomains.append(subdomain.strip())
         except Exception:
             pass
 

--- a/sublist3r.py
+++ b/sublist3r.py
@@ -676,8 +676,9 @@ class DNSdumpster(enumratorBaseThreaded):
 class Virustotal(enumratorBaseThreaded):
     def __init__(self, domain, subdomains=None, q=None, silent=False, verbose=True):
         subdomains = subdomains or []
-        base_url = 'https://www.virustotal.com/ui/domains/{domain}/subdomains'
+        base_url = 'https://www.virustotal.com/api/v3/domains/{domain}'
         self.engine_name = "Virustotal"
+        self.apikey = os.getenv('VT_APIKEY', None)
         self.q = q
         super(Virustotal, self).__init__(base_url, self.engine_name, domain, subdomains, q=q, silent=silent, verbose=verbose)
         self.url = self.base_url.format(domain=self.domain)
@@ -686,40 +687,42 @@ class Virustotal(enumratorBaseThreaded):
     # the main send_req need to be rewritten
     def send_req(self, url):
         try:
+            self.headers.update({'X-ApiKey': self.apikey})
             resp = self.session.get(url, headers=self.headers, timeout=self.timeout)
         except Exception as e:
             self.print_(e)
             resp = None
-
         return self.get_response(resp)
 
     # once the send_req is rewritten we don't need to call this function, the stock one should be ok
     def enumerate(self):
-        while self.url != '':
-            resp = self.send_req(self.url)
-            resp = json.loads(resp)
-            if 'error' in resp:
-                self.print_(R + "[!] Error: Virustotal probably now is blocking our requests" + W)
-                break
-            if 'links' in resp and 'next' in resp['links']:
-                self.url = resp['links']['next']
-            else:
-                self.url = ''
-            self.extract_domains(resp)
+        if self.apikey:
+            while self.url != '':
+                resp = self.send_req(self.url)
+                resp = json.loads(resp)
+                if 'error' in resp:
+                    self.print_(R + "[!] Error: Virustotal probably now is blocking our requests" + W)
+                    break
+                if 'links' in resp and 'next' in resp['links']:
+                    self.url = resp['links']['next']
+                else:
+                    self.url = ''
+                self.extract_domains(resp)
+        else:
+            self.print_(R + "[!] Error: VirusTotal API key environment variable not found. Skipping" + W)
         return self.subdomains
 
     def extract_domains(self, resp):
         #resp is already parsed as json
         try:
-            for i in resp['data']:
-                if i['type'] == 'domain':
-                    subdomain = i['id']
-                    if not subdomain.endswith(self.domain):
-                        continue
-                    if subdomain not in self.subdomains and subdomain != self.domain:
-                        if self.verbose:
-                            self.print_("%s%s: %s%s" % (R, self.engine_name, W, subdomain))
-                        self.subdomains.append(subdomain.strip())
+            for i in resp['data']['attributes']['last_dns_records']:
+                subdomain = i['value']
+                if not subdomain.endswith(self.domain):
+                    continue
+                if subdomain not in self.subdomains and subdomain != self.domain:
+                    if self.verbose:
+                        self.print_("%s%s: %s%s" % (R, self.engine_name, W, subdomain))
+                    self.subdomains.append(subdomain.strip())
         except Exception:
             pass
 


### PR DESCRIPTION
This PR fixes the outdated VirusTotal API endpoint which has been reported in https://github.com/aboul3la/Sublist3r/issues/194. It uses the value specified in the `VT_APIKEY`environment variable. If the the API key is missing, it prints an error message and skips the VirusTotal engine.

<img width="865" alt="Screen Shot 2020-11-22 at 00 38 26" src="https://user-images.githubusercontent.com/172588/99890077-e4f77200-2c5b-11eb-9d45-17ccfe2e56d1.png">
