### PR TITLE
Fix DeprecationWarning on line 614

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -611,7 +611,7 @@ class DNSdumpster(enumratorBaseThreaded):
         Resolver.nameservers = ['8.8.8.8', '8.8.4.4']
         self.lock.acquire()
         try:
-            ip = Resolver.query(host, 'A')[0].to_text()
+            ip = Resolver.resolve(host, 'A', search=True)[0].to_text()
             if ip:
                 if self.verbose:
                     self.print_("%s%s: %s%s" % (R, self.engine_name, W, host))


### PR DESCRIPTION
cc @aboul3la.

This change fixes a DeprecationWarning caused by the [deprecation of Resolver.query](https://dnspython.readthedocs.io/en/latest/resolver-class.html#dns.resolver.Resolver.query) in the latest version of dnspython.