### PR TITLE
fix subbrute resolve.query() & virustotal access

### DIFF
--- a/subbrute/subbrute.py
+++ b/subbrute/subbrute.py
@@ -67,7 +67,7 @@ class verify_nameservers(multiprocessing.Process):
             #Lets test the letancy of our connection.
             #Google's DNS server should be an ideal time test.
             resolver.nameservers = ['8.8.8.8']
-            resolver.query(self.most_popular_website, self.record_type)
+            resolver.resolve(self.most_popular_website, self.record_type)
         except:
             #Our connection is slower than a junebug in molasses
             resolver = dns.resolver.Resolver()
@@ -98,7 +98,7 @@ class verify_nameservers(multiprocessing.Process):
             if server:
                 self.resolver.nameservers = [server]
                 try:
-                    #test_result = self.resolver.query(self.most_popular_website, "A")
+                    #test_result = self.resolver.resolve(self.most_popular_website, "A")
                     #should throw an exception before this line.
                     if True:#test_result:
                         #Only add the nameserver to the queue if we can detect wildcards. 
@@ -138,7 +138,7 @@ class verify_nameservers(multiprocessing.Process):
         #I have seen a CloudFlare Enterprise customer with the first two conditions.
         try:
             #This is case #3,  these spam nameservers seem to be more trouble then they are worth.
-             wildtest = self.resolver.query(uuid.uuid4().hex + ".com", "A")
+             wildtest = self.resolver.resolve(uuid.uuid4().hex + ".com", "A")
              if len(wildtest):
                 trace("Spam DNS detected:", host)
                 return False
@@ -152,7 +152,7 @@ class verify_nameservers(multiprocessing.Process):
             test_counter -= 1            
             try:
                 testdomain = "%s.%s" % (uuid.uuid4().hex, host)
-                wildtest = self.resolver.query(testdomain, self.record_type)
+                wildtest = self.resolver.resolve(testdomain, self.record_type)
                 #This 'A' record may contain a list of wildcards.
                 if wildtest:
                     for w in wildtest:
@@ -224,7 +224,7 @@ class lookup(multiprocessing.Process):
             try:
                 #Query the nameserver, this is not simple...
                 if not record_type or record_type == "A":
-                    resp = self.resolver.query(host)
+                    resp = self.resolver.resolve(host)
                     #Crawl the response
                     hosts = extract_hosts(str(resp.response), self.domain)
                     for h in hosts:
@@ -237,7 +237,7 @@ class lookup(multiprocessing.Process):
                     #A max 20 lookups
                     for x in range(20):
                         try:
-                            resp = self.resolver.query(host, record_type)
+                            resp = self.resolver.resolve(host, record_type)
                         except dns.resolver.NoAnswer:
                             resp = False
                             pass
@@ -248,7 +248,7 @@ class lookup(multiprocessing.Process):
                             return cname_record                    
                 else:
                     #All other records:
-                    return self.resolver.query(host, record_type)
+                    return self.resolver.resolve(host, record_type)
 
             except Exception as e:
                 if type(e) == dns.resolver.NoNameservers:

--- a/sublist3r.py
+++ b/sublist3r.py
@@ -676,7 +676,7 @@ class DNSdumpster(enumratorBaseThreaded):
 class Virustotal(enumratorBaseThreaded):
     def __init__(self, domain, subdomains=None, q=None, silent=False, verbose=True):
         subdomains = subdomains or []
-        base_url = 'https://www.virustotal.com/ui/domains/{domain}/subdomains'
+        base_url = 'https://www.virustotal.com/gui/domain/{domain}/details'
         self.engine_name = "Virustotal"
         self.q = q
         super(Virustotal, self).__init__(base_url, self.engine_name, domain, subdomains, q=q, silent=silent, verbose=verbose)


### PR DESCRIPTION
- Fix subbrute resolve.query deprecation warning with python3+ versions.
- Fix virus total access error message by updating url used in sublist3r.py to access virustotal results