### PR TITLE
Virustotal is probably blocking the request

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -676,7 +676,7 @@ class DNSdumpster(enumratorBaseThreaded):
 class Virustotal(enumratorBaseThreaded):
     def __init__(self, domain, subdomains=None, q=None, silent=False, verbose=True):
         subdomains = subdomains or []
-        base_url = 'https://www.virustotal.com/ui/domains/{domain}/subdomains'
+        base_url = 'https://www.virustotal.com/gui/domain/{{dommain}}/details';
         self.engine_name = "Virustotal"
         self.q = q
         super(Virustotal, self).__init__(base_url, self.engine_name, domain, subdomains, q=q, silent=silent, verbose=verbose)


### PR DESCRIPTION
Virustotal is probably blocking the request because virustotal subdomain base URL is changed by virustotal.
So, Sublist3r got an error of virustotal probably blocking the request.
But now it is processing after it's updation. It is now just show following error text now, but just wait it will got work:

Process Virustotal-9:
Traceback (most recent call last):
  File "/usr/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/root/Sublist3r/sublist3r.py", line 268, in run
    domain_list = self.enumerate()
  File "/root/Sublist3r/sublist3r.py", line 700, in enumerate
    resp = json.loads(resp)
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
/root/Sublist3r/sublist3r.py:614: DeprecationWarning: please use dns.resolver.Resolver.resolve() instead
  ip = Resolver.query(host, 'A')[0].to_text()


***NOTE: This is a very important update so that users can get help to use it conveniently.