### PR TITLE
exception handled for ssl verification error

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -565,10 +565,12 @@ class NetcraftEnum(enumratorBaseThreaded):
     def enumerate(self):
         start_url = self.base_url.format(domain='example.com')
         resp = self.req(start_url)
-        cookies = self.get_cookies(resp.headers)
+        cookies = self.get_cookies(resp.headers) if resp else {}
         url = self.base_url.format(domain=self.domain)
         while True:
             resp = self.get_response(self.req(url, cookies))
+            if resp == 0:
+                return self.subdomains
             self.extract_domains(resp)
             if 'Next Page' not in resp:
                 return self.subdomains


### PR DESCRIPTION
While investigating issue #312. It was throwing an ugly exception which can be avoided by just taking care of default values.... Now it is not showing exceptions on the screen.  

Here is the screenshot after code changes.
![Screenshot from 2021-05-12 06-33-44](https://user-images.githubusercontent.com/21127788/117902873-0cb2c300-b2ec-11eb-8fa1-7f6021f54de3.png)

To fix SSL verification issue, we need to pass ```verify=False``` as an argument in the get request of NetcraftEnum engine. If we hard code value of verify  it will be same for all the domains. If we want it to be optional then  we need to take it's value as an input and will need to update all the engines. But it will be insecure and will be prone to MITM.

What do you guys think please let me know!
Thank you