### PR TITLE
Update Hash Function in sublist3r

### DIFF
--- a/sublist3r.py
+++ b/sublist3r.py
@@ -552,7 +552,8 @@ class NetcraftEnum(enumratorBaseThreaded):
         cookies_list = cookie[0:cookie.find(';')].split("=")
         cookies[cookies_list[0]] = cookies_list[1]
         # hashlib.sha1 requires utf-8 encoded str
-        cookies['netcraft_js_verification_response'] = hashlib.sha1(urllib.unquote(cookies_list[1]).encode('utf-8')).hexdigest()
+        # replacing sha1 with sha512 for better security purposes
+        cookies['netcraft_js_verification_response'] = hashlib.sha512(urllib.unquote(cookies_list[1]).encode('utf-8')).hexdigest()
         return cookies
 
     def get_cookies(self, headers):


### PR DESCRIPTION
SHA1 signature algorithm is considered to be insecure these days because of its vulnerability towards collision attacks. Attackers can exploit this to generate another certificate with same digital signature, allowing them to disguise and pretend themselves as official authority and affect the actual services.
So replaced the SHA1 algorithm with SHA512 in sublist3r.py file at line no 555 to strengthen the security aspects of the digital certificate verification purpose.