### PR TITLE
Fix syntax warnings and improve DNSdumpster error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+build/
+dist/
+Sublist3r.egg-info/

--- a/subbrute/subbrute.py
+++ b/subbrute/subbrute.py
@@ -371,7 +371,7 @@ def extract_hosts(data, hostname):
 
 #Return a list of unique sub domains,  sorted by frequency.
 #Only match domains that have 3 or more sections subdomain.domain.tld
-domain_match = re.compile("([a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]*)+")
+domain_match = re.compile(r"([a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]*)+")
 def extract_subdomains(file_name):
     #Avoid re-compilation
     global domain_match


### PR DESCRIPTION
- Fix invalid escape sequence warnings by using raw strings for regex patterns
- Remove unnecessary escaping in HTML regex patterns
- Add robust error handling for DNSdumpster CSRF token extraction
- Improve graceful failure when CSRF token cannot be found
- Add alternative CSRF token regex patterns for better compatibility

Fixes Python 3.12+ syntax warnings and prevents crashes when DNSdumpster structure changes.