### PR TITLE
Fix ImportError: cannot import name 'subbrute' from 'subbrute'

### DIFF
--- a/subbrute/__init__.py
+++ b/subbrute/__init__.py
@@ -1,0 +1,2 @@
+# Fix ImportError by exporting subbrute module contents
+from .subbrute import *


### PR DESCRIPTION
## Problem

ImportError when running sublist3r:
```
ImportError: cannot import name 'subbrute' from 'subbrute'
```

## Solution

Added missing exports to `subbrute/__init__.py`:
```python
from .subbrute import *
```

This allows `from subbrute import subbrute` to work correctly when the package is installed.

## Testing

- Verified the import works after the fix
- No breaking changes to existing functionality

## Issue

Fixes #388